### PR TITLE
feat(web): foster application wizard at /foster/apply (PR 2/5)

### DIFF
--- a/apps/admin/app/api/email/foster-admin-new-submission/route.ts
+++ b/apps/admin/app/api/email/foster-admin-new-submission/route.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from "next/server"
+import { validateEmailRequest } from "../_lib"
+import { sendFosterAdminNewSubmissionEmail } from "@/app/_lib/email"
+
+export async function POST(request: Request) {
+    const result = await validateEmailRequest(request)
+    if ("error" in result) return result.error
+
+    const { applicantName, fosterApplicationId, adminUrl } = result.data
+    if (!applicantName || !fosterApplicationId || !adminUrl) {
+        return NextResponse.json({ error: "Missing required fields" }, { status: 400 })
+    }
+
+    try {
+        await sendFosterAdminNewSubmissionEmail({
+            applicantName,
+            fosterApplicationId,
+            adminUrl,
+        })
+        return NextResponse.json({ ok: true })
+    } catch (error) {
+        console.error("[email/foster-admin-new-submission] Failed:", error)
+        return NextResponse.json({ error: "Failed to send email" }, { status: 500 })
+    }
+}

--- a/apps/admin/app/api/email/foster-magic-link/route.ts
+++ b/apps/admin/app/api/email/foster-magic-link/route.ts
@@ -1,0 +1,21 @@
+import { NextResponse } from "next/server"
+import { validateEmailRequest } from "../_lib"
+import { sendFosterMagicLinkEmail } from "@/app/_lib/email"
+
+export async function POST(request: Request) {
+    const result = await validateEmailRequest(request)
+    if ("error" in result) return result.error
+
+    const { to, firstName, url } = result.data
+    if (!to || !firstName || !url) {
+        return NextResponse.json({ error: "Missing required fields" }, { status: 400 })
+    }
+
+    try {
+        await sendFosterMagicLinkEmail({ to, firstName, url })
+        return NextResponse.json({ ok: true })
+    } catch (error) {
+        console.error("[email/foster-magic-link] Failed:", error)
+        return NextResponse.json({ error: "Failed to send email" }, { status: 500 })
+    }
+}

--- a/apps/admin/app/api/email/foster-submission-confirmation/route.ts
+++ b/apps/admin/app/api/email/foster-submission-confirmation/route.ts
@@ -1,0 +1,21 @@
+import { NextResponse } from "next/server"
+import { validateEmailRequest } from "../_lib"
+import { sendFosterSubmissionConfirmationEmail } from "@/app/_lib/email"
+
+export async function POST(request: Request) {
+    const result = await validateEmailRequest(request)
+    if ("error" in result) return result.error
+
+    const { to, firstName, applicationUrl } = result.data
+    if (!to || !firstName || !applicationUrl) {
+        return NextResponse.json({ error: "Missing required fields" }, { status: 400 })
+    }
+
+    try {
+        await sendFosterSubmissionConfirmationEmail({ to, firstName, applicationUrl })
+        return NextResponse.json({ ok: true })
+    } catch (error) {
+        console.error("[email/foster-submission-confirmation] Failed:", error)
+        return NextResponse.json({ error: "Failed to send email" }, { status: 500 })
+    }
+}

--- a/apps/web/app/foster/apply/_actions/application.ts
+++ b/apps/web/app/foster/apply/_actions/application.ts
@@ -1,0 +1,241 @@
+"use server"
+
+import { randomBytes } from "crypto"
+import { redirect } from "next/navigation"
+import { FOSTER_SECTION_KEYS, type FosterSectionKey } from "@repo/database"
+import {
+    createFosterApplication,
+    createFosterApplicationToken,
+    deleteFosterApplicationTokens,
+    getFosterApplicationByEmail,
+    getFosterApplicationByToken,
+    getLatestFosterSections,
+    saveFosterSection,
+    submitFosterApplication,
+} from "@repo/database"
+import {
+    FOSTER_CONDITIONAL_RULES,
+    FOSTER_SECTION_CONFIG_MAP,
+    getVisibleFields,
+    getRequiredVisibleFields,
+} from "@repo/types"
+import { getFosterApplicationCookie } from "../_lib/application-session"
+
+async function sendAdminEmail(endpoint: string, data: Record<string, unknown>) {
+    const adminUrl = process.env.ADMIN_INTERNAL_URL
+    const secret = process.env.REVALIDATION_SECRET
+
+    if (!adminUrl || !secret) {
+        console.warn("[email] ADMIN_INTERNAL_URL or REVALIDATION_SECRET not set — skipping email")
+        return
+    }
+
+    const res = await fetch(`${adminUrl}/api/email/${endpoint}`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ ...data, secret }),
+    })
+
+    if (!res.ok) {
+        throw new Error(`Email API failed: ${res.status} ${await res.text()}`)
+    }
+}
+
+export type MagicLinkState = { success: true; message: string } | { errors: string[] } | undefined
+
+export type SaveSectionState = { success: true } | { errors: Record<string, string> } | undefined
+
+export type SubmitState = { success: true } | { error: string } | undefined
+
+export async function requestMagicLink(
+    _prevState: MagicLinkState,
+    formData: FormData,
+): Promise<MagicLinkState> {
+    const email = formData.get("email")
+    const firstName = formData.get("firstName")
+    const lastName = formData.get("lastName")
+
+    if (!email || typeof email !== "string" || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+        return { errors: ["Please enter a valid email address."] }
+    }
+    if (!firstName || typeof firstName !== "string" || firstName.trim().length === 0) {
+        return { errors: ["Please enter your first name."] }
+    }
+    if (!lastName || typeof lastName !== "string" || lastName.trim().length === 0) {
+        return { errors: ["Please enter your last name."] }
+    }
+
+    const existing = await getFosterApplicationByEmail(email)
+    let applicationId: number
+    if (existing) {
+        applicationId = existing.id
+    } else {
+        const result = await createFosterApplication({
+            email,
+            firstName: firstName.trim(),
+            lastName: lastName.trim(),
+        })
+        applicationId = result.id
+    }
+
+    await deleteFosterApplicationTokens(applicationId)
+    const token = randomBytes(32).toString("hex")
+    const expiresAt = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000) // 7 days
+    await createFosterApplicationToken(applicationId, token, expiresAt)
+
+    const baseUrl = process.env.NEXT_PUBLIC_SITE_URL ?? "http://localhost:3000"
+    const url = `${baseUrl}/foster/apply/callback?token=${token}`
+    await sendAdminEmail("foster-magic-link", {
+        to: email,
+        firstName: firstName.trim(),
+        url,
+    })
+
+    return {
+        success: true,
+        message: "Check your email! We've sent you a link to access your application.",
+    }
+}
+
+export async function getFosterApplicationFromCookie() {
+    const token = await getFosterApplicationCookie()
+    if (!token) return null
+
+    const result = await getFosterApplicationByToken(token)
+    if (!result) return null
+
+    const { application, token: tokenRecord } = result
+    if (new Date(tokenRecord.expiresAt) < new Date()) return null
+
+    return application
+}
+
+function parseSectionFormData(
+    formData: FormData,
+    sectionKey: FosterSectionKey,
+): Record<string, unknown> {
+    const config = FOSTER_SECTION_CONFIG_MAP[sectionKey]
+    if (!config) return {}
+
+    const data: Record<string, unknown> = {}
+
+    for (const field of config.fields) {
+        if (field.type === "checkbox") {
+            data[field.name] = formData.getAll(field.name)
+        } else if (field.type === "repeating" && field.subFields) {
+            const entries: Record<string, unknown>[] = []
+            const countStr = formData.get(`${field.name}__count`)
+            const count = countStr ? parseInt(String(countStr), 10) : 0
+            for (let i = 0; i < count; i++) {
+                const entry: Record<string, unknown> = {}
+                for (const sub of field.subFields) {
+                    const val = formData.get(`${field.name}[${i}].${sub.name}`)
+                    entry[sub.name] = val ? String(val) : ""
+                }
+                entries.push(entry)
+            }
+            data[field.name] = entries
+        } else if (field.type === "number" || field.type === "scale") {
+            const val = formData.get(field.name)
+            data[field.name] = val ? Number(val) : undefined
+        } else {
+            const val = formData.get(field.name)
+            data[field.name] = val ? String(val) : undefined
+        }
+    }
+
+    return data
+}
+
+export async function saveSectionAction(
+    applicationId: number,
+    sectionKey: FosterSectionKey,
+    _prevState: SaveSectionState,
+    formData: FormData,
+): Promise<SaveSectionState> {
+    const data = parseSectionFormData(formData, sectionKey)
+
+    const allSectionsRaw = await getLatestFosterSections(applicationId)
+    const allSectionsData: Partial<Record<FosterSectionKey, Record<string, unknown>>> = {}
+    for (const { section } of allSectionsRaw) {
+        allSectionsData[section.sectionKey as FosterSectionKey] = section.data as Record<
+            string,
+            unknown
+        >
+    }
+    allSectionsData[sectionKey] = data
+
+    const visibleFields = getVisibleFields(
+        sectionKey,
+        data,
+        allSectionsData,
+        FOSTER_CONDITIONAL_RULES,
+        FOSTER_SECTION_CONFIG_MAP,
+    )
+    const requiredFields = getRequiredVisibleFields(
+        sectionKey,
+        data,
+        allSectionsData,
+        FOSTER_CONDITIONAL_RULES,
+        FOSTER_SECTION_CONFIG_MAP,
+    )
+
+    const errors: Record<string, string> = {}
+    for (const fieldName of requiredFields) {
+        const value = data[fieldName]
+        if (value === undefined || value === null || value === "") {
+            errors[fieldName] = "This field is required."
+        } else if (Array.isArray(value) && value.length === 0) {
+            errors[fieldName] = "Please select at least one option."
+        }
+    }
+
+    if (Object.keys(errors).length > 0) {
+        return { errors }
+    }
+
+    const visibleData: Record<string, unknown> = {}
+    for (const [key, value] of Object.entries(data)) {
+        if (visibleFields.has(key)) {
+            visibleData[key] = value
+        }
+    }
+
+    await saveFosterSection(applicationId, sectionKey, visibleData)
+    return { success: true }
+}
+
+export async function submitApplicationAction(applicationId: number): Promise<SubmitState> {
+    const allSections = await getLatestFosterSections(applicationId)
+    const savedKeys = new Set(allSections.map((s) => s.section.sectionKey))
+    const missing = FOSTER_SECTION_KEYS.filter((key) => !savedKeys.has(key))
+
+    if (missing.length > 0) {
+        return { error: "Please complete all sections before submitting." }
+    }
+
+    await submitFosterApplication(applicationId)
+
+    const application = await getFosterApplicationFromCookie()
+    if (application) {
+        const baseUrl = process.env.NEXT_PUBLIC_SITE_URL ?? "http://localhost:3000"
+        const adminUrl = process.env.NEXT_PUBLIC_ADMIN_URL ?? "http://localhost:3001"
+
+        Promise.all([
+            sendAdminEmail("foster-submission-confirmation", {
+                to: application.email,
+                firstName: application.firstName,
+                applicationUrl: `${baseUrl}/foster/apply`,
+            }),
+            sendAdminEmail("foster-admin-new-submission", {
+                applicantName: `${application.firstName} ${application.lastName}`,
+                fosterApplicationId: application.id,
+                adminUrl: `${adminUrl}/fosters/${application.id}`,
+            }),
+        ]).catch(() => {
+            // Email failures shouldn't affect the user
+        })
+    }
+
+    redirect("/foster/apply/status")
+}

--- a/apps/web/app/foster/apply/_components/application-context.tsx
+++ b/apps/web/app/foster/apply/_components/application-context.tsx
@@ -1,0 +1,30 @@
+"use client"
+
+import { createContext, useContext } from "react"
+import type { FosterApplicationStatus, FosterSectionKey } from "@repo/database"
+
+interface FosterApplicationContextValue {
+    applicationId: number
+    status: FosterApplicationStatus
+    completedSections: FosterSectionKey[]
+}
+
+const FosterApplicationContext = createContext<FosterApplicationContextValue | null>(null)
+
+export function FosterApplicationProvider({
+    children,
+    value,
+}: {
+    children: React.ReactNode
+    value: FosterApplicationContextValue
+}) {
+    return <FosterApplicationContext value={value}>{children}</FosterApplicationContext>
+}
+
+export function useFosterApplication() {
+    const context = useContext(FosterApplicationContext)
+    if (!context) {
+        throw new Error("useFosterApplication must be used within a FosterApplicationProvider")
+    }
+    return context
+}

--- a/apps/web/app/foster/apply/_components/field-renderer.tsx
+++ b/apps/web/app/foster/apply/_components/field-renderer.tsx
@@ -1,0 +1,347 @@
+"use client"
+
+import type { FieldDef } from "@repo/types"
+import { Input } from "@repo/ui/components/input"
+import { Textarea } from "@repo/ui/components/textarea"
+import { Label } from "@repo/ui/components/label"
+import { Checkbox } from "@repo/ui/components/checkbox"
+import { RadioGroup, RadioGroupItem } from "@repo/ui/components/radio-group"
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from "@repo/ui/components/select"
+import { Button } from "@repo/ui/components/button"
+import { cn } from "@repo/ui/lib/utils"
+import { Plus, Trash2 } from "lucide-react"
+
+interface FieldRendererProps {
+    field: FieldDef
+    value: unknown
+    onChange: (name: string, value: unknown) => void
+    error?: string
+    /** Prefix for repeating field entry names */
+    namePrefix?: string
+}
+
+export function FieldRenderer({ field, value, onChange, error, namePrefix }: FieldRendererProps) {
+    const fieldName = namePrefix ? `${namePrefix}.${field.name}` : field.name
+    const stringValue = value != null ? String(value) : ""
+
+    return (
+        <div className="space-y-2">
+            {field.type !== "checkbox" && field.type !== "repeating" && field.type !== "scale" && (
+                <Label htmlFor={fieldName}>
+                    {field.label}
+                    {field.required && <span className="text-destructive ml-1">*</span>}
+                </Label>
+            )}
+            {field.helpText && <p className="text-muted-foreground text-sm">{field.helpText}</p>}
+
+            {renderField(field, fieldName, value, stringValue, onChange)}
+
+            {error && <p className="text-destructive text-sm">{error}</p>}
+        </div>
+    )
+}
+
+function renderField(
+    field: FieldDef,
+    fieldName: string,
+    value: unknown,
+    stringValue: string,
+    onChange: (name: string, value: unknown) => void,
+) {
+    switch (field.type) {
+        case "text":
+        case "email":
+        case "phone":
+            return (
+                <Input
+                    id={fieldName}
+                    name={fieldName}
+                    type={field.type === "phone" ? "tel" : field.type}
+                    value={stringValue}
+                    onChange={(e) => onChange(field.name, e.target.value)}
+                    placeholder={field.placeholder}
+                />
+            )
+
+        case "number":
+            return (
+                <Input
+                    id={fieldName}
+                    name={fieldName}
+                    type="number"
+                    value={stringValue}
+                    onChange={(e) =>
+                        onChange(field.name, e.target.value ? Number(e.target.value) : undefined)
+                    }
+                    min={field.min}
+                    max={field.max}
+                    placeholder={field.placeholder}
+                />
+            )
+
+        case "textarea":
+            return (
+                <Textarea
+                    id={fieldName}
+                    name={fieldName}
+                    value={stringValue}
+                    onChange={(e) => onChange(field.name, e.target.value)}
+                    placeholder={field.placeholder}
+                />
+            )
+
+        case "radio":
+            return (
+                <RadioGroup
+                    name={fieldName}
+                    value={stringValue}
+                    onValueChange={(v) => onChange(field.name, v)}
+                >
+                    {field.options?.map((opt) => (
+                        <div key={opt.value} className="flex items-center gap-2">
+                            <RadioGroupItem value={opt.value} id={`${fieldName}-${opt.value}`} />
+                            <Label htmlFor={`${fieldName}-${opt.value}`} className="font-normal">
+                                {opt.label}
+                            </Label>
+                        </div>
+                    ))}
+                </RadioGroup>
+            )
+
+        case "dropdown":
+            return (
+                <Select
+                    name={fieldName}
+                    value={stringValue}
+                    onValueChange={(v) => onChange(field.name, v)}
+                >
+                    <SelectTrigger className="w-full">
+                        <SelectValue placeholder={field.placeholder ?? "Select..."} />
+                    </SelectTrigger>
+                    <SelectContent>
+                        {field.options?.map((opt) => (
+                            <SelectItem key={opt.value} value={opt.value}>
+                                {opt.label}
+                            </SelectItem>
+                        ))}
+                    </SelectContent>
+                </Select>
+            )
+
+        case "checkbox":
+            return (
+                <CheckboxGroup
+                    field={field}
+                    fieldName={fieldName}
+                    value={value}
+                    onChange={onChange}
+                />
+            )
+
+        case "scale":
+            return (
+                <ScaleInput field={field} fieldName={fieldName} value={value} onChange={onChange} />
+            )
+
+        case "repeating":
+            return (
+                <RepeatingField
+                    field={field}
+                    fieldName={fieldName}
+                    value={value}
+                    onChange={onChange}
+                />
+            )
+
+        default:
+            return null
+    }
+}
+
+function CheckboxGroup({
+    field,
+    fieldName,
+    value,
+    onChange,
+}: {
+    field: FieldDef
+    fieldName: string
+    value: unknown
+    onChange: (name: string, value: unknown) => void
+}) {
+    const selected = Array.isArray(value) ? (value as string[]) : []
+
+    return (
+        <fieldset className="space-y-2">
+            <legend className="text-sm font-medium">
+                {field.label}
+                {field.required && <span className="text-destructive ml-1">*</span>}
+            </legend>
+            {field.options?.map((opt) => (
+                <div key={opt.value} className="flex items-center gap-2">
+                    <Checkbox
+                        id={`${fieldName}-${opt.value}`}
+                        name={fieldName}
+                        value={opt.value}
+                        checked={selected.includes(opt.value)}
+                        onCheckedChange={(checked) => {
+                            const next = checked
+                                ? [...selected, opt.value]
+                                : selected.filter((v) => v !== opt.value)
+                            onChange(field.name, next)
+                        }}
+                    />
+                    <Label htmlFor={`${fieldName}-${opt.value}`} className="font-normal">
+                        {opt.label}
+                    </Label>
+                </div>
+            ))}
+        </fieldset>
+    )
+}
+
+function ScaleInput({
+    field,
+    fieldName,
+    value,
+    onChange,
+}: {
+    field: FieldDef
+    fieldName: string
+    value: unknown
+    onChange: (name: string, value: unknown) => void
+}) {
+    const min = field.scaleMin ?? 1
+    const max = field.scaleMax ?? 5
+    const current = typeof value === "number" ? value : undefined
+    const points = Array.from({ length: max - min + 1 }, (_, i) => min + i)
+
+    return (
+        <fieldset className="space-y-2">
+            <legend className="text-sm font-medium">
+                {field.label}
+                {field.required && <span className="text-destructive ml-1">*</span>}
+            </legend>
+            <div className="flex items-center gap-1">
+                {field.scaleMinLabel && (
+                    <span className="text-muted-foreground mr-2 text-xs">
+                        {field.scaleMinLabel}
+                    </span>
+                )}
+                {points.map((point) => (
+                    <button
+                        key={point}
+                        type="button"
+                        onClick={() => onChange(field.name, point)}
+                        className={cn(
+                            "flex size-9 items-center justify-center rounded-md border text-sm font-medium transition-colors",
+                            current === point
+                                ? "bg-primary text-primary-foreground border-primary"
+                                : "hover:bg-accent",
+                        )}
+                    >
+                        {point}
+                    </button>
+                ))}
+                {field.scaleMaxLabel && (
+                    <span className="text-muted-foreground ml-2 text-xs">
+                        {field.scaleMaxLabel}
+                    </span>
+                )}
+                <input type="hidden" name={fieldName} value={current ?? ""} />
+            </div>
+        </fieldset>
+    )
+}
+
+function RepeatingField({
+    field,
+    fieldName,
+    value,
+    onChange,
+}: {
+    field: FieldDef
+    fieldName: string
+    value: unknown
+    onChange: (name: string, value: unknown) => void
+}) {
+    const entries = Array.isArray(value) ? (value as Record<string, unknown>[]) : []
+    const minEntries = field.minEntries ?? 0
+    const maxEntries = field.maxEntries ?? 10
+
+    function addEntry() {
+        if (entries.length >= maxEntries) return
+        const newEntry: Record<string, unknown> = {}
+        for (const sub of field.subFields ?? []) {
+            newEntry[sub.name] = ""
+        }
+        onChange(field.name, [...entries, newEntry])
+    }
+
+    function removeEntry(index: number) {
+        if (entries.length <= minEntries) return
+        onChange(
+            field.name,
+            entries.filter((_, i) => i !== index),
+        )
+    }
+
+    function updateEntry(index: number, subName: string, subValue: unknown) {
+        const next = entries.map((entry, i) =>
+            i === index ? { ...entry, [subName]: subValue } : entry,
+        )
+        onChange(field.name, next)
+    }
+
+    return (
+        <fieldset className="space-y-3">
+            <legend className="text-sm font-medium">
+                {field.label}
+                {field.required && <span className="text-destructive ml-1">*</span>}
+            </legend>
+            <input type="hidden" name={`${fieldName}__count`} value={entries.length} />
+            {entries.map((entry, index) => (
+                <div key={index} className="rounded-lg border p-4">
+                    <div className="mb-3 flex items-center justify-between">
+                        <span className="text-muted-foreground text-sm">#{index + 1}</span>
+                        {entries.length > minEntries && (
+                            <Button
+                                type="button"
+                                variant="ghost"
+                                size="icon-xs"
+                                onClick={() => removeEntry(index)}
+                            >
+                                <Trash2 className="size-3.5" />
+                            </Button>
+                        )}
+                    </div>
+                    <div className="grid gap-3 sm:grid-cols-3">
+                        {field.subFields?.map((sub) => (
+                            <div key={sub.name} className="space-y-1">
+                                <Label className="text-xs">{sub.label}</Label>
+                                <Input
+                                    name={`${fieldName}[${index}].${sub.name}`}
+                                    value={String(entry[sub.name] ?? "")}
+                                    onChange={(e) => updateEntry(index, sub.name, e.target.value)}
+                                    placeholder={sub.placeholder}
+                                />
+                            </div>
+                        ))}
+                    </div>
+                </div>
+            ))}
+            {entries.length < maxEntries && (
+                <Button type="button" variant="outline" size="sm" onClick={addEntry}>
+                    <Plus className="size-3.5" />
+                    Add
+                </Button>
+            )}
+        </fieldset>
+    )
+}

--- a/apps/web/app/foster/apply/_components/magic-link-form.tsx
+++ b/apps/web/app/foster/apply/_components/magic-link-form.tsx
@@ -1,0 +1,52 @@
+"use client"
+
+import { useActionState } from "react"
+import { CheckCircle2, Loader2, Mail } from "lucide-react"
+import { Button } from "@repo/ui/components/button"
+import { Input } from "@repo/ui/components/input"
+import { Label } from "@repo/ui/components/label"
+import { requestMagicLink } from "../_actions/application"
+
+export function MagicLinkForm() {
+    const [state, formAction, isPending] = useActionState(requestMagicLink, undefined)
+
+    if (state && "success" in state) {
+        return (
+            <div className="rounded-lg border p-6 text-center">
+                <CheckCircle2 className="mx-auto mb-3 size-10 text-green-500" />
+                <h2 className="mb-1 text-lg font-semibold">Check Your Email</h2>
+                <p className="text-muted-foreground text-sm">{state.message}</p>
+            </div>
+        )
+    }
+
+    return (
+        <form action={formAction} className="space-y-4">
+            <div className="space-y-2">
+                <Label htmlFor="email">Email address</Label>
+                <Input id="email" name="email" type="email" required placeholder="your@email.com" />
+            </div>
+            <div className="grid grid-cols-2 gap-4">
+                <div className="space-y-2">
+                    <Label htmlFor="firstName">First name</Label>
+                    <Input id="firstName" name="firstName" required placeholder="First" />
+                </div>
+                <div className="space-y-2">
+                    <Label htmlFor="lastName">Last name</Label>
+                    <Input id="lastName" name="lastName" required placeholder="Last" />
+                </div>
+            </div>
+            {state?.errors && <p className="text-destructive text-sm">{state.errors[0]}</p>}
+            <Button type="submit" disabled={isPending} className="w-full">
+                {isPending ? (
+                    <Loader2 className="size-4 animate-spin" />
+                ) : (
+                    <>
+                        <Mail className="size-4" />
+                        Send Application Link
+                    </>
+                )}
+            </Button>
+        </form>
+    )
+}

--- a/apps/web/app/foster/apply/_components/progress-bar.tsx
+++ b/apps/web/app/foster/apply/_components/progress-bar.tsx
@@ -1,0 +1,72 @@
+"use client"
+
+import Link from "next/link"
+import { usePathname } from "next/navigation"
+import { FOSTER_SECTION_KEYS } from "@repo/database/schema"
+import { FOSTER_SECTION_CONFIG_MAP } from "@repo/types"
+import { cn } from "@repo/ui/lib/utils"
+import { useFosterApplication } from "./application-context"
+import { toSlug, isSectionAccessible } from "../_lib/section-slugs"
+
+export function ProgressBar() {
+    const pathname = usePathname()
+    const { completedSections } = useFosterApplication()
+
+    const segments = pathname.split("/")
+    const currentSlug = segments[segments.length - 1]
+
+    return (
+        <div className="space-y-3">
+            <div className="flex items-center justify-between gap-1">
+                {FOSTER_SECTION_KEYS.map((key, index) => {
+                    const slug = toSlug(key)
+                    const isCompleted = completedSections.includes(key)
+                    const isCurrent = currentSlug === slug
+                    const isAccessible = isSectionAccessible(key, completedSections)
+
+                    const dot = (
+                        <div
+                            className={cn(
+                                "flex size-8 items-center justify-center rounded-full text-xs font-medium transition-colors",
+                                isCurrent &&
+                                    "bg-primary text-primary-foreground ring-primary/30 ring-2",
+                                isCompleted && !isCurrent && "bg-primary/20 text-primary",
+                                !isCompleted && !isCurrent && "bg-muted text-muted-foreground",
+                            )}
+                        >
+                            {index + 1}
+                        </div>
+                    )
+
+                    if (isAccessible && !isCurrent) {
+                        return (
+                            <Link
+                                key={key}
+                                href={`/foster/apply/wizard/${slug}`}
+                                className="group flex flex-col items-center"
+                            >
+                                {dot}
+                            </Link>
+                        )
+                    }
+
+                    return (
+                        <div key={key} className="flex flex-col items-center">
+                            {dot}
+                        </div>
+                    )
+                })}
+            </div>
+            {FOSTER_SECTION_KEYS.map((key) => {
+                const slug = toSlug(key)
+                if (currentSlug !== slug) return null
+                const config = FOSTER_SECTION_CONFIG_MAP[key]
+                return (
+                    <p key={key} className="text-muted-foreground text-center text-sm">
+                        {config?.title}
+                    </p>
+                )
+            })}
+        </div>
+    )
+}

--- a/apps/web/app/foster/apply/_components/section-summary.tsx
+++ b/apps/web/app/foster/apply/_components/section-summary.tsx
@@ -1,0 +1,53 @@
+import type { FosterSectionKey } from "@repo/database"
+import type { SectionConfig } from "@repo/types"
+import { FOSTER_CONDITIONAL_RULES, FOSTER_SECTION_CONFIG_MAP, getVisibleFields } from "@repo/types"
+
+interface SectionSummaryProps {
+    sectionConfig: SectionConfig<FosterSectionKey>
+    data: Record<string, unknown>
+    allSectionsData: Partial<Record<FosterSectionKey, Record<string, unknown>>>
+}
+
+export function SectionSummary({ sectionConfig, data, allSectionsData }: SectionSummaryProps) {
+    const visibleFields = getVisibleFields(
+        sectionConfig.key,
+        data,
+        { ...allSectionsData, [sectionConfig.key]: data },
+        FOSTER_CONDITIONAL_RULES,
+        FOSTER_SECTION_CONFIG_MAP,
+    )
+
+    return (
+        <div className="space-y-3">
+            {sectionConfig.fields.map((field) => {
+                if (!visibleFields.has(field.name)) return null
+                const value = data[field.name]
+                if (value === undefined || value === null || value === "") return null
+
+                return (
+                    <div key={field.name} className="grid grid-cols-[1fr_2fr] gap-2 text-sm">
+                        <dt className="text-muted-foreground">{field.label}</dt>
+                        <dd>{formatValue(value)}</dd>
+                    </div>
+                )
+            })}
+        </div>
+    )
+}
+
+function formatValue(value: unknown): string {
+    if (Array.isArray(value)) {
+        if (value.length === 0) return "—"
+        if (typeof value[0] === "object") {
+            return value
+                .map((entry: Record<string, unknown>) =>
+                    Object.values(entry).filter(Boolean).join(", "),
+                )
+                .join(" | ")
+        }
+        return value.join(", ")
+    }
+    if (typeof value === "number") return String(value)
+    if (typeof value === "string") return value
+    return String(value)
+}

--- a/apps/web/app/foster/apply/_components/submit-dialog.tsx
+++ b/apps/web/app/foster/apply/_components/submit-dialog.tsx
@@ -1,0 +1,68 @@
+"use client"
+
+import { useState } from "react"
+import { Loader2 } from "lucide-react"
+import { Button } from "@repo/ui/components/button"
+import {
+    AlertDialog,
+    AlertDialogAction,
+    AlertDialogCancel,
+    AlertDialogContent,
+    AlertDialogDescription,
+    AlertDialogFooter,
+    AlertDialogHeader,
+    AlertDialogTitle,
+    AlertDialogTrigger,
+} from "@repo/ui/components/alert-dialog"
+import { submitApplicationAction } from "../_actions/application"
+
+interface SubmitDialogProps {
+    applicationId: number
+}
+
+export function SubmitDialog({ applicationId }: SubmitDialogProps) {
+    const [isPending, setIsPending] = useState(false)
+    const [error, setError] = useState<string | null>(null)
+
+    async function handleSubmit() {
+        setIsPending(true)
+        setError(null)
+        const result = await submitApplicationAction(applicationId)
+        if (result && "error" in result) {
+            setError(result.error)
+        }
+        setIsPending(false)
+    }
+
+    return (
+        <div className="space-y-2">
+            {error && <p className="text-destructive text-sm">{error}</p>}
+            <AlertDialog>
+                <AlertDialogTrigger asChild>
+                    <Button size="lg" className="w-full">
+                        Submit Application
+                    </Button>
+                </AlertDialogTrigger>
+                <AlertDialogContent>
+                    <AlertDialogHeader>
+                        <AlertDialogTitle>Submit your foster application?</AlertDialogTitle>
+                        <AlertDialogDescription>
+                            Once submitted, you won&apos;t be able to make changes. Please make sure
+                            all information is correct before proceeding.
+                        </AlertDialogDescription>
+                    </AlertDialogHeader>
+                    <AlertDialogFooter>
+                        <AlertDialogCancel>Go Back</AlertDialogCancel>
+                        <AlertDialogAction onClick={handleSubmit} disabled={isPending}>
+                            {isPending ? (
+                                <Loader2 className="size-4 animate-spin" />
+                            ) : (
+                                "Yes, Submit"
+                            )}
+                        </AlertDialogAction>
+                    </AlertDialogFooter>
+                </AlertDialogContent>
+            </AlertDialog>
+        </div>
+    )
+}

--- a/apps/web/app/foster/apply/_components/wizard-section-form.tsx
+++ b/apps/web/app/foster/apply/_components/wizard-section-form.tsx
@@ -1,0 +1,129 @@
+"use client"
+
+import { useActionState, useState, useCallback, useRef } from "react"
+import { useRouter } from "next/navigation"
+import type { FosterSectionKey } from "@repo/database"
+import type { SectionConfig } from "@repo/types"
+import { FOSTER_CONDITIONAL_RULES, FOSTER_SECTION_CONFIG_MAP, getVisibleFields } from "@repo/types"
+import { Button } from "@repo/ui/components/button"
+import { Loader2 } from "lucide-react"
+import { toast } from "sonner"
+import { saveSectionAction, type SaveSectionState } from "../_actions/application"
+import { FieldRenderer } from "./field-renderer"
+import { getNextSectionSlug } from "../_lib/section-slugs"
+
+interface WizardSectionFormProps {
+    sectionConfig: SectionConfig<FosterSectionKey>
+    savedData: Record<string, unknown>
+    allSectionsData: Partial<Record<FosterSectionKey, Record<string, unknown>>>
+    applicationId: number
+}
+
+export function WizardSectionForm({
+    sectionConfig,
+    savedData,
+    allSectionsData,
+    applicationId,
+}: WizardSectionFormProps) {
+    const router = useRouter()
+    const [formData, setFormData] = useState<Record<string, unknown>>(savedData)
+    const intentRef = useRef<"save" | "continue">("continue")
+
+    const visibleFields = getVisibleFields(
+        sectionConfig.key,
+        formData,
+        { ...allSectionsData, [sectionConfig.key]: formData },
+        FOSTER_CONDITIONAL_RULES,
+        FOSTER_SECTION_CONFIG_MAP,
+    )
+
+    const boundAction = saveSectionAction.bind(null, applicationId, sectionConfig.key)
+
+    const [state, formAction, isPending] = useActionState(
+        async (prevState: SaveSectionState, fd: FormData) => {
+            const result = await boundAction(prevState, fd)
+            if (result && "success" in result) {
+                if (intentRef.current === "continue") {
+                    const nextSlug = getNextSectionSlug(sectionConfig.key)
+                    if (nextSlug) {
+                        router.push(`/foster/apply/wizard/${nextSlug}`)
+                    } else {
+                        router.push("/foster/apply/review")
+                    }
+                } else {
+                    toast.success("Progress saved")
+                }
+            }
+            return result
+        },
+        undefined,
+    )
+
+    const handleChange = useCallback((name: string, value: unknown) => {
+        setFormData((prev) => ({ ...prev, [name]: value }))
+    }, [])
+
+    const errors = state && "errors" in state ? state.errors : {}
+    const nextSlug = getNextSectionSlug(sectionConfig.key)
+    const isLastSection = !nextSlug
+
+    return (
+        <div className="space-y-6">
+            <div>
+                <h1 className="font-heading text-3xl tracking-wide">{sectionConfig.title}</h1>
+                {sectionConfig.description && (
+                    <p className="text-muted-foreground mt-1 text-sm">
+                        {sectionConfig.description}
+                    </p>
+                )}
+            </div>
+
+            <form action={formAction} className="space-y-6">
+                {sectionConfig.fields.map((field) => {
+                    if (!visibleFields.has(field.name)) return null
+                    return (
+                        <FieldRenderer
+                            key={field.name}
+                            field={field}
+                            value={formData[field.name]}
+                            onChange={handleChange}
+                            error={errors[field.name]}
+                        />
+                    )
+                })}
+
+                <div className="flex gap-3 pt-4">
+                    <Button
+                        type="submit"
+                        disabled={isPending}
+                        onClick={() => {
+                            intentRef.current = "continue"
+                        }}
+                    >
+                        {isPending && intentRef.current === "continue" ? (
+                            <Loader2 className="size-4 animate-spin" />
+                        ) : isLastSection ? (
+                            "Save & Review"
+                        ) : (
+                            "Save & Continue"
+                        )}
+                    </Button>
+                    <Button
+                        type="submit"
+                        variant="outline"
+                        disabled={isPending}
+                        onClick={() => {
+                            intentRef.current = "save"
+                        }}
+                    >
+                        {isPending && intentRef.current === "save" ? (
+                            <Loader2 className="size-4 animate-spin" />
+                        ) : (
+                            "Save"
+                        )}
+                    </Button>
+                </div>
+            </form>
+        </div>
+    )
+}

--- a/apps/web/app/foster/apply/_lib/application-session.ts
+++ b/apps/web/app/foster/apply/_lib/application-session.ts
@@ -1,0 +1,25 @@
+import { cookies } from "next/headers"
+
+const COOKIE_NAME = "foster_application_token"
+const COOKIE_MAX_AGE = 60 * 60 * 24 * 7 // 7 days
+
+export async function setFosterApplicationCookie(token: string) {
+    const cookieStore = await cookies()
+    cookieStore.set(COOKIE_NAME, token, {
+        httpOnly: true,
+        sameSite: "lax",
+        secure: process.env.NODE_ENV === "production",
+        path: "/foster/apply",
+        maxAge: COOKIE_MAX_AGE,
+    })
+}
+
+export async function getFosterApplicationCookie(): Promise<string | null> {
+    const cookieStore = await cookies()
+    return cookieStore.get(COOKIE_NAME)?.value ?? null
+}
+
+export async function clearFosterApplicationCookie() {
+    const cookieStore = await cookies()
+    cookieStore.delete(COOKIE_NAME)
+}

--- a/apps/web/app/foster/apply/_lib/section-slugs.ts
+++ b/apps/web/app/foster/apply/_lib/section-slugs.ts
@@ -1,0 +1,50 @@
+import { FOSTER_SECTION_KEYS, type FosterSectionKey } from "@repo/database/schema"
+
+export function toSlug(sectionKey: FosterSectionKey): string {
+    return sectionKey.replaceAll("_", "-")
+}
+
+export function toSectionKey(slug: string): FosterSectionKey | null {
+    const key = slug.replaceAll("-", "_")
+    if (FOSTER_SECTION_KEYS.includes(key as FosterSectionKey)) {
+        return key as FosterSectionKey
+    }
+    return null
+}
+
+export function getNextSectionSlug(currentKey: FosterSectionKey): string | null {
+    const index = FOSTER_SECTION_KEYS.indexOf(currentKey)
+    if (index < 0 || index >= FOSTER_SECTION_KEYS.length - 1) return null
+    return toSlug(FOSTER_SECTION_KEYS[index + 1]!)
+}
+
+export function getPreviousSectionKey(currentKey: FosterSectionKey): FosterSectionKey | null {
+    const index = FOSTER_SECTION_KEYS.indexOf(currentKey)
+    if (index <= 0) return null
+    return FOSTER_SECTION_KEYS[index - 1]!
+}
+
+export function getFirstIncompleteSectionSlug(
+    completedSections: FosterSectionKey[],
+): string | null {
+    for (const key of FOSTER_SECTION_KEYS) {
+        if (!completedSections.includes(key)) {
+            return toSlug(key)
+        }
+    }
+    return null
+}
+
+export function isSectionAccessible(
+    sectionKey: FosterSectionKey,
+    completedSections: FosterSectionKey[],
+): boolean {
+    const index = FOSTER_SECTION_KEYS.indexOf(sectionKey)
+    if (index === 0) return true
+    for (let i = 0; i < index; i++) {
+        if (!completedSections.includes(FOSTER_SECTION_KEYS[i]!)) {
+            return false
+        }
+    }
+    return true
+}

--- a/apps/web/app/foster/apply/callback/route.ts
+++ b/apps/web/app/foster/apply/callback/route.ts
@@ -1,0 +1,33 @@
+import { NextRequest, NextResponse } from "next/server"
+import { getFosterApplicationByToken } from "@repo/database"
+
+const COOKIE_NAME = "foster_application_token"
+const COOKIE_MAX_AGE = 60 * 60 * 24 * 7 // 7 days
+
+export async function GET(request: NextRequest) {
+    const token = request.nextUrl.searchParams.get("token")
+
+    if (!token) {
+        return NextResponse.redirect(new URL("/foster/apply", request.url))
+    }
+
+    const result = await getFosterApplicationByToken(token)
+    if (!result || new Date(result.token.expiresAt) < new Date()) {
+        return NextResponse.redirect(new URL("/foster/apply", request.url))
+    }
+
+    const { application } = result
+    const destination =
+        application.status !== "draft" ? "/foster/apply/status" : "/foster/apply/wizard"
+
+    const response = NextResponse.redirect(new URL(destination, request.url))
+    response.cookies.set(COOKIE_NAME, token, {
+        httpOnly: true,
+        sameSite: "lax",
+        secure: process.env.NODE_ENV === "production",
+        path: "/foster/apply",
+        maxAge: COOKIE_MAX_AGE,
+    })
+
+    return response
+}

--- a/apps/web/app/foster/apply/layout.tsx
+++ b/apps/web/app/foster/apply/layout.tsx
@@ -1,0 +1,23 @@
+import type { Metadata } from "next"
+import Link from "next/link"
+
+export const metadata: Metadata = {
+    title: "Foster Application | GPA-MN",
+    description: "Apply to foster a retired racing greyhound for GPA-MN.",
+}
+
+export default function ApplyLayout({ children }: { children: React.ReactNode }) {
+    return (
+        <div className="flex min-h-screen flex-col">
+            <header className="border-b py-4">
+                <div className="container mx-auto flex items-center px-4">
+                    <Link href="/" className="font-heading text-2xl tracking-wide">
+                        GPA-MN
+                    </Link>
+                    <span className="text-muted-foreground ml-3 text-sm">Foster Application</span>
+                </div>
+            </header>
+            <main className="flex flex-1 flex-col">{children}</main>
+        </div>
+    )
+}

--- a/apps/web/app/foster/apply/page.tsx
+++ b/apps/web/app/foster/apply/page.tsx
@@ -1,0 +1,30 @@
+import { redirect } from "next/navigation"
+import { getFosterApplicationFromCookie } from "./_actions/application"
+import { MagicLinkForm } from "./_components/magic-link-form"
+
+export default async function ApplyPage() {
+    const application = await getFosterApplicationFromCookie()
+    if (application) {
+        if (application.status !== "draft") {
+            redirect("/foster/apply/status")
+        }
+        redirect("/foster/apply/wizard")
+    }
+
+    return (
+        <div className="flex flex-1 items-center justify-center px-4 py-12">
+            <div className="w-full max-w-md space-y-6">
+                <div className="space-y-2 text-center">
+                    <h1 className="font-heading text-4xl tracking-wide">
+                        Start Your Foster Application
+                    </h1>
+                    <p className="text-muted-foreground text-sm">
+                        Enter your information below and we&apos;ll send you a secure link to access
+                        your application. You can save your progress and return anytime.
+                    </p>
+                </div>
+                <MagicLinkForm />
+            </div>
+        </div>
+    )
+}

--- a/apps/web/app/foster/apply/review/page.tsx
+++ b/apps/web/app/foster/apply/review/page.tsx
@@ -1,0 +1,87 @@
+import { redirect } from "next/navigation"
+import Link from "next/link"
+import { FOSTER_SECTION_KEYS, type FosterSectionKey } from "@repo/database"
+import { getFosterApplicationByToken, getLatestFosterSections } from "@repo/database"
+import { FOSTER_SECTION_CONFIG_MAP } from "@repo/types"
+import { Toaster } from "@repo/ui/components/sonner"
+import { getFosterApplicationCookie } from "../_lib/application-session"
+import { toSlug, getFirstIncompleteSectionSlug } from "../_lib/section-slugs"
+import { SectionSummary } from "../_components/section-summary"
+import { SubmitDialog } from "../_components/submit-dialog"
+
+export default async function ReviewPage() {
+    const token = await getFosterApplicationCookie()
+    if (!token) redirect("/foster/apply")
+
+    const result = await getFosterApplicationByToken(token)
+    if (!result || new Date(result.token.expiresAt) < new Date()) {
+        redirect("/foster/apply")
+    }
+
+    const { application } = result
+
+    if (application.status !== "draft") {
+        redirect("/foster/apply/status")
+    }
+
+    const allSectionsRaw = await getLatestFosterSections(application.id)
+    const completedSections = allSectionsRaw.map((s) => s.section.sectionKey) as FosterSectionKey[]
+
+    const firstIncomplete = getFirstIncompleteSectionSlug(completedSections)
+    if (firstIncomplete) {
+        redirect(`/foster/apply/wizard/${firstIncomplete}`)
+    }
+
+    const allSectionsData: Partial<Record<FosterSectionKey, Record<string, unknown>>> = {}
+    for (const { section } of allSectionsRaw) {
+        allSectionsData[section.sectionKey as FosterSectionKey] = section.data as Record<
+            string,
+            unknown
+        >
+    }
+
+    return (
+        <div className="container mx-auto max-w-3xl px-4 py-8">
+            <div className="space-y-2">
+                <h1 className="font-heading text-4xl tracking-wide">Review Your Application</h1>
+                <p className="text-muted-foreground text-sm">
+                    Please review your answers below. You can edit any section before submitting.
+                </p>
+            </div>
+
+            <div className="mt-8 space-y-8">
+                {FOSTER_SECTION_KEYS.map((key) => {
+                    const config = FOSTER_SECTION_CONFIG_MAP[key]
+                    const data = (allSectionsData[key] ?? {}) as Record<string, unknown>
+                    if (!config) return null
+
+                    return (
+                        <section key={key} className="space-y-3">
+                            <div className="flex items-center justify-between">
+                                <h2 className="font-heading text-2xl tracking-wide">
+                                    {config.title}
+                                </h2>
+                                <Link
+                                    href={`/foster/apply/wizard/${toSlug(key)}`}
+                                    className="text-primary text-sm hover:underline"
+                                >
+                                    Edit
+                                </Link>
+                            </div>
+                            <SectionSummary
+                                sectionConfig={config}
+                                data={data}
+                                allSectionsData={allSectionsData}
+                            />
+                        </section>
+                    )
+                })}
+            </div>
+
+            <div className="mt-10">
+                <SubmitDialog applicationId={application.id} />
+            </div>
+            <Toaster position="top-center" />
+        </div>
+    )
+}

--- a/apps/web/app/foster/apply/status/page.tsx
+++ b/apps/web/app/foster/apply/status/page.tsx
@@ -1,0 +1,83 @@
+import { redirect } from "next/navigation"
+import { FOSTER_SECTION_KEYS, type FosterSectionKey } from "@repo/database"
+import { getFosterApplicationByToken, getLatestFosterSections } from "@repo/database"
+import { FOSTER_SECTION_CONFIG_MAP } from "@repo/types"
+import { Badge } from "@repo/ui/components/badge"
+import { getFosterApplicationCookie } from "../_lib/application-session"
+import { SectionSummary } from "../_components/section-summary"
+
+const STATUS_LABELS: Record<
+    string,
+    { label: string; variant: "default" | "secondary" | "outline" | "destructive" }
+> = {
+    submitted: { label: "Submitted", variant: "default" },
+    in_review: { label: "In Review", variant: "secondary" },
+    approved: { label: "Approved", variant: "default" },
+    denied: { label: "Denied", variant: "destructive" },
+    on_hold: { label: "On Hold", variant: "outline" },
+    draft: { label: "Draft", variant: "outline" },
+}
+
+export default async function StatusPage() {
+    const token = await getFosterApplicationCookie()
+    if (!token) redirect("/foster/apply")
+
+    const result = await getFosterApplicationByToken(token)
+    if (!result || new Date(result.token.expiresAt) < new Date()) {
+        redirect("/foster/apply")
+    }
+
+    const { application } = result
+
+    if (application.status === "draft") {
+        redirect("/foster/apply/wizard")
+    }
+
+    const allSectionsRaw = await getLatestFosterSections(application.id)
+    const allSectionsData: Partial<Record<FosterSectionKey, Record<string, unknown>>> = {}
+    for (const { section } of allSectionsRaw) {
+        allSectionsData[section.sectionKey as FosterSectionKey] = section.data as Record<
+            string,
+            unknown
+        >
+    }
+
+    const statusInfo = STATUS_LABELS[application.status] ?? {
+        label: application.status,
+        variant: "outline" as const,
+    }
+
+    return (
+        <div className="container mx-auto max-w-3xl px-4 py-8">
+            <div className="space-y-3">
+                <div className="flex items-center gap-3">
+                    <h1 className="font-heading text-4xl tracking-wide">Your Foster Application</h1>
+                    <Badge variant={statusInfo.variant}>{statusInfo.label}</Badge>
+                </div>
+                <p className="text-muted-foreground text-sm">
+                    Your application has been submitted. You&apos;ll receive an email when the
+                    status changes.
+                </p>
+            </div>
+
+            <div className="mt-8 space-y-8">
+                {FOSTER_SECTION_KEYS.map((key) => {
+                    const config = FOSTER_SECTION_CONFIG_MAP[key]
+                    const data = (allSectionsData[key] ?? {}) as Record<string, unknown>
+                    if (!config) return null
+
+                    return (
+                        <section key={key} className="space-y-3">
+                            <h2 className="font-heading text-2xl tracking-wide">{config.title}</h2>
+                            <SectionSummary
+                                sectionConfig={config}
+                                data={data}
+                                allSectionsData={allSectionsData}
+                            />
+                        </section>
+                    )
+                })}
+            </div>
+        </div>
+    )
+}

--- a/apps/web/app/foster/apply/wizard/[section]/page.tsx
+++ b/apps/web/app/foster/apply/wizard/[section]/page.tsx
@@ -1,0 +1,59 @@
+import { notFound, redirect } from "next/navigation"
+import type { FosterSectionKey } from "@repo/database"
+import { getFosterApplicationByToken, getLatestFosterSections } from "@repo/database"
+import { FOSTER_SECTION_CONFIG_MAP } from "@repo/types"
+import { getFosterApplicationCookie } from "../../_lib/application-session"
+import {
+    toSectionKey,
+    isSectionAccessible,
+    getFirstIncompleteSectionSlug,
+} from "../../_lib/section-slugs"
+import { WizardSectionForm } from "../../_components/wizard-section-form"
+
+export default async function SectionPage({ params }: { params: Promise<{ section: string }> }) {
+    const { section: slug } = await params
+    const sectionKey = toSectionKey(slug)
+    if (!sectionKey) notFound()
+
+    const sectionConfig = FOSTER_SECTION_CONFIG_MAP[sectionKey]
+    if (!sectionConfig) notFound()
+
+    const token = await getFosterApplicationCookie()
+    if (!token) redirect("/foster/apply")
+
+    const result = await getFosterApplicationByToken(token)
+    if (!result || new Date(result.token.expiresAt) < new Date()) {
+        redirect("/foster/apply")
+    }
+
+    const { application } = result
+
+    const allSectionsRaw = await getLatestFosterSections(application.id)
+    const completedSections = allSectionsRaw.map((s) => s.section.sectionKey) as FosterSectionKey[]
+
+    if (!isSectionAccessible(sectionKey, completedSections)) {
+        const firstIncomplete = getFirstIncompleteSectionSlug(completedSections)
+        if (firstIncomplete) {
+            redirect(`/foster/apply/wizard/${firstIncomplete}`)
+        }
+    }
+
+    const allSectionsData: Partial<Record<FosterSectionKey, Record<string, unknown>>> = {}
+    let savedData: Record<string, unknown> = {}
+    for (const { section } of allSectionsRaw) {
+        const data = section.data as Record<string, unknown>
+        allSectionsData[section.sectionKey as FosterSectionKey] = data
+        if (section.sectionKey === sectionKey) {
+            savedData = data
+        }
+    }
+
+    return (
+        <WizardSectionForm
+            sectionConfig={sectionConfig}
+            savedData={savedData}
+            allSectionsData={allSectionsData}
+            applicationId={application.id}
+        />
+    )
+}

--- a/apps/web/app/foster/apply/wizard/layout.tsx
+++ b/apps/web/app/foster/apply/wizard/layout.tsx
@@ -1,0 +1,41 @@
+import { redirect } from "next/navigation"
+import type { FosterSectionKey } from "@repo/database"
+import { getFosterApplicationByToken, getLatestFosterSections } from "@repo/database"
+import { Toaster } from "@repo/ui/components/sonner"
+import { getFosterApplicationCookie } from "../_lib/application-session"
+import { FosterApplicationProvider } from "../_components/application-context"
+import { ProgressBar } from "../_components/progress-bar"
+
+export default async function WizardLayout({ children }: { children: React.ReactNode }) {
+    const token = await getFosterApplicationCookie()
+    if (!token) redirect("/foster/apply")
+
+    const result = await getFosterApplicationByToken(token)
+    if (!result || new Date(result.token.expiresAt) < new Date()) {
+        redirect("/foster/apply")
+    }
+
+    const { application } = result
+    if (application.status !== "draft") {
+        redirect("/foster/apply/status")
+    }
+
+    const allSections = await getLatestFosterSections(application.id)
+    const completedSections = allSections.map((s) => s.section.sectionKey) as FosterSectionKey[]
+
+    return (
+        <FosterApplicationProvider
+            value={{
+                applicationId: application.id,
+                status: application.status,
+                completedSections,
+            }}
+        >
+            <div className="container mx-auto max-w-3xl px-4 py-8">
+                <ProgressBar />
+                <div className="mt-8">{children}</div>
+            </div>
+            <Toaster position="top-center" />
+        </FosterApplicationProvider>
+    )
+}

--- a/apps/web/app/foster/apply/wizard/page.tsx
+++ b/apps/web/app/foster/apply/wizard/page.tsx
@@ -1,0 +1,25 @@
+import { redirect } from "next/navigation"
+import type { FosterSectionKey } from "@repo/database"
+import { getFosterApplicationByToken, getLatestFosterSections } from "@repo/database"
+import { getFosterApplicationCookie } from "../_lib/application-session"
+import { getFirstIncompleteSectionSlug } from "../_lib/section-slugs"
+
+export default async function WizardIndexPage() {
+    const token = await getFosterApplicationCookie()
+    if (!token) redirect("/foster/apply")
+
+    const result = await getFosterApplicationByToken(token)
+    if (!result || new Date(result.token.expiresAt) < new Date()) {
+        redirect("/foster/apply")
+    }
+
+    const allSections = await getLatestFosterSections(result.application.id)
+    const completedSections = allSections.map((s) => s.section.sectionKey) as FosterSectionKey[]
+
+    const firstIncompleteSlug = getFirstIncompleteSectionSlug(completedSections)
+    if (firstIncompleteSlug) {
+        redirect(`/foster/apply/wizard/${firstIncompleteSlug}`)
+    }
+
+    redirect("/foster/apply/review")
+}

--- a/apps/web/app/volunteer/page.tsx
+++ b/apps/web/app/volunteer/page.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link"
 import {
     getVolunteerRoles,
     getPageHeader,
@@ -64,12 +65,12 @@ export default async function VolunteerPage() {
                                         />
                                     )}
                                     <div className="mt-8">
-                                        <a
-                                            href="mailto:fostering@gpa-mn.org"
+                                        <Link
+                                            href="/foster/apply"
                                             className="bg-primary hover:bg-primary/90 inline-flex items-center gap-2 rounded-full px-8 py-3.5 font-semibold text-white shadow-[0_4px_16px_rgba(156,47,48,0.25)] transition-colors"
                                         >
                                             Apply to Foster
-                                        </a>
+                                        </Link>
                                     </div>
                                 </div>
                             </div>


### PR DESCRIPTION
Second of 5 PRs. Closes #9. **Base branch: `feat/foster-application` (stacked on #13).**

## Summary

- Full `/foster/apply` tree parallel to `/adopt/apply`: magic-link entry, email callback, wizard layout/index/[section], review page with submit dialog, post-submit status page.
- `foster_application_token` cookie scoped to `/foster/apply` — no collision with adoption.
- Wizard rendering uses shared `getVisibleFields` engine with `FOSTER_CONDITIONAL_RULES` and `FOSTER_SECTION_CONFIG_MAP`.
- Three admin email API routes added: `foster-magic-link`, `foster-submission-confirmation`, `foster-admin-new-submission`.
- `/volunteer` "Apply to Foster" CTA now links to `/foster/apply` (was `mailto:fostering@gpa-mn.org`).

## Out of scope
- Admin list → PR 3 (#10)
- Admin detail → PR 4 (#11)
- Consolidate duplicated `FieldRenderer` to `@repo/ui` → polish (#12)

## Test plan
- [x] `pnpm typecheck` / `pnpm lint` / `pnpm test` green
- [ ] Manual walk-through: request magic link → receive email → click → land on wizard → fill all 10 sections (esp. conditional branches for co-applicant, rent, fenced-yard, children reading) → review → submit → see status page
- [ ] `/volunteer` "Apply to Foster" link lands on `/foster/apply`

🤖 Generated with [Claude Code](https://claude.com/claude-code)