### PR TITLE
feat(admin): foster applications list at /admin/fosters (PR 3/5)

### DIFF
--- a/apps/admin/app/(admin)/fosters/_components/fosters-filter.tsx
+++ b/apps/admin/app/(admin)/fosters/_components/fosters-filter.tsx
@@ -1,0 +1,87 @@
+"use client"
+
+import { useRouter, usePathname } from "next/navigation"
+import { useTransition } from "react"
+import { Input } from "@repo/ui/components/input"
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from "@repo/ui/components/select"
+import { Search } from "lucide-react"
+
+const STATUS_OPTIONS = [
+    { value: "active", label: "All (excl. drafts)" },
+    { value: "all", label: "All (incl. drafts)" },
+    { value: "submitted", label: "Submitted" },
+    { value: "in_review", label: "In Review" },
+    { value: "approved", label: "Approved" },
+    { value: "denied", label: "Denied" },
+    { value: "on_hold", label: "On Hold" },
+    { value: "draft", label: "Draft" },
+]
+
+interface FostersFilterProps {
+    currentStatus: string
+    currentSearch: string
+}
+
+export function FostersFilter({ currentStatus, currentSearch }: FostersFilterProps) {
+    const router = useRouter()
+    const pathname = usePathname()
+    const [, startTransition] = useTransition()
+
+    function updateParams(key: string, value: string) {
+        const params = new URLSearchParams()
+        const nextStatus = key === "status" ? value : currentStatus
+        const nextSearch = key === "search" ? value : currentSearch
+
+        if (nextStatus && nextStatus !== "active") params.set("status", nextStatus)
+        if (nextSearch) params.set("search", nextSearch)
+
+        const qs = params.toString()
+        startTransition(() => {
+            router.replace(qs ? `${pathname}?${qs}` : pathname)
+        })
+    }
+
+    return (
+        <div className="mb-4 flex items-center gap-3">
+            <Select
+                value={currentStatus || "active"}
+                onValueChange={(value) => updateParams("status", value)}
+            >
+                <SelectTrigger className="w-48">
+                    <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                    {STATUS_OPTIONS.map((opt) => (
+                        <SelectItem key={opt.value} value={opt.value}>
+                            {opt.label}
+                        </SelectItem>
+                    ))}
+                </SelectContent>
+            </Select>
+            <div className="relative">
+                <Search className="text-muted-foreground absolute top-2.5 left-2.5 h-4 w-4" />
+                <Input
+                    placeholder="Search name or email..."
+                    defaultValue={currentSearch}
+                    className="w-64 pl-9"
+                    onKeyDown={(e) => {
+                        if (e.key === "Enter") {
+                            updateParams("search", e.currentTarget.value)
+                        }
+                    }}
+                    onBlur={(e) => {
+                        if (e.target.value !== currentSearch) {
+                            updateParams("search", e.target.value)
+                        }
+                    }}
+                />
+            </div>
+        </div>
+    )
+}

--- a/apps/admin/app/(admin)/fosters/_components/status-badge.tsx
+++ b/apps/admin/app/(admin)/fosters/_components/status-badge.tsx
@@ -1,0 +1,19 @@
+import { Badge } from "@repo/ui/components/badge"
+import type { FosterApplicationStatus } from "@repo/database"
+
+const STATUS_CONFIG: Record<
+    FosterApplicationStatus,
+    { label: string; variant: "default" | "secondary" | "destructive" | "outline" }
+> = {
+    draft: { label: "Draft", variant: "outline" },
+    submitted: { label: "Submitted", variant: "default" },
+    in_review: { label: "In Review", variant: "secondary" },
+    approved: { label: "Approved", variant: "default" },
+    denied: { label: "Denied", variant: "destructive" },
+    on_hold: { label: "On Hold", variant: "outline" },
+}
+
+export function StatusBadge({ status }: { status: FosterApplicationStatus }) {
+    const config = STATUS_CONFIG[status]
+    return <Badge variant={config.variant}>{config.label}</Badge>
+}

--- a/apps/admin/app/(admin)/fosters/_lib/derive-columns.ts
+++ b/apps/admin/app/(admin)/fosters/_lib/derive-columns.ts
@@ -1,0 +1,65 @@
+export type FosterDerivedColumns = {
+    pets: "Yes" | "No" | null
+    kids: "Yes" | "No" | null
+    housing: string | null
+    referral: string | null
+    alsoAdopting: "Yes" | "No" | null
+}
+
+type SectionData = Record<string, unknown> | undefined
+
+function derivePets(data: SectionData): FosterDerivedColumns["pets"] {
+    if (!data) return null
+    if (data.hasCurrentPets === "Yes") return "Yes"
+    if (data.hasCurrentPets === "No") return "No"
+    return null
+}
+
+function deriveKids(data: SectionData): FosterDerivedColumns["kids"] {
+    if (!data) return null
+    if (data.hasChildren5to8 === "Yes" || data.hasChildrenUnder5 === "Yes") return "Yes"
+    return "No"
+}
+
+function deriveHousing(data: SectionData): FosterDerivedColumns["housing"] {
+    if (!data) return null
+    const homeType = data.homeType as string | undefined
+    const hasFence = data.hasFencedYard as string | undefined
+    if (!homeType) return null
+    if (homeType === "House" && hasFence === "Yes") return "House w/ fence"
+    if (homeType === "House") return "House no fence"
+    if (homeType === "Apartment") return "Apartment"
+    if (homeType === "Condo" || homeType === "Townhouse") return "Shared Walls"
+    return homeType
+}
+
+function deriveReferral(data: SectionData): FosterDerivedColumns["referral"] {
+    if (!data) return null
+    const arr = data.howHeardAboutGPA
+    if (!Array.isArray(arr) || arr.length === 0) return null
+    return arr.join(", ")
+}
+
+function deriveAlsoAdopting(data: SectionData): FosterDerivedColumns["alsoAdopting"] {
+    if (!data) return null
+    if (data.alsoInterestedInAdopting === "Yes") return "Yes"
+    if (data.alsoInterestedInAdopting === "No") return "No"
+    return null
+}
+
+export function deriveAllColumns(
+    sections: Partial<Record<string, Record<string, unknown>>>,
+): FosterDerivedColumns {
+    return {
+        pets: derivePets(sections["current_pets"]),
+        kids: deriveKids(sections["household"]),
+        housing: deriveHousing(sections["home"]),
+        referral: deriveReferral(sections["final_questions"]),
+        alsoAdopting: deriveAlsoAdopting(sections["foster_preferences"]),
+    }
+}
+
+export function computeAgeDays(submittedAt: Date | null): number | null {
+    if (!submittedAt) return null
+    return Math.floor((Date.now() - new Date(submittedAt).getTime()) / (1000 * 60 * 60 * 24))
+}

--- a/apps/admin/app/(admin)/fosters/loading.tsx
+++ b/apps/admin/app/(admin)/fosters/loading.tsx
@@ -1,0 +1,5 @@
+import { TableSkeleton } from "@/app/_components/table-skeleton"
+
+export default function Loading() {
+    return <TableSkeleton title="Foster Applications" columns={9} />
+}

--- a/apps/admin/app/(admin)/fosters/page.tsx
+++ b/apps/admin/app/(admin)/fosters/page.tsx
@@ -1,0 +1,151 @@
+import Link from "next/link"
+import {
+    listFosterApplications,
+    getLatestFosterSectionsForApplications,
+    type FosterApplicationStatus,
+} from "@repo/database"
+import { requireSectionAccess } from "@/app/_lib/require-section-access"
+import {
+    Table,
+    TableBody,
+    TableCell,
+    TableHead,
+    TableHeader,
+    TableRow,
+} from "@repo/ui/components/table"
+import { FostersFilter } from "./_components/fosters-filter"
+import { StatusBadge } from "./_components/status-badge"
+import { deriveAllColumns, computeAgeDays, type FosterDerivedColumns } from "./_lib/derive-columns"
+
+interface PageProps {
+    searchParams: Promise<{ status?: string; search?: string }>
+}
+
+export default async function FostersPage({ searchParams }: PageProps) {
+    await requireSectionAccess("fosters")
+
+    const params = await searchParams
+    const statusFilter = params.status as FosterApplicationStatus | "all" | "active" | undefined
+    const filters: { status?: FosterApplicationStatus; search?: string } = {}
+
+    if (statusFilter && statusFilter !== "all" && statusFilter !== "active") {
+        filters.status = statusFilter
+    }
+    if (params.search) {
+        filters.search = params.search
+    }
+
+    const results = await listFosterApplications(filters)
+
+    // Default: exclude drafts unless a specific status is chosen
+    const rows =
+        statusFilter && statusFilter !== "active"
+            ? results
+            : results.filter((r) => r.application.status !== "draft")
+
+    // Batch-fetch section data for derived columns
+    const applicationIds = rows.map((r) => r.application.id)
+    const sectionRows = await getLatestFosterSectionsForApplications(applicationIds, [
+        "current_pets",
+        "household",
+        "home",
+        "final_questions",
+        "foster_preferences",
+    ])
+
+    const sectionMap = new Map<number, Partial<Record<string, Record<string, unknown>>>>()
+    for (const row of sectionRows) {
+        if (!sectionMap.has(row.fosterApplicationId)) {
+            sectionMap.set(row.fosterApplicationId, {})
+        }
+        sectionMap.get(row.fosterApplicationId)![row.sectionKey] = row.data as Record<
+            string,
+            unknown
+        >
+    }
+
+    const derivedMap = new Map<number, FosterDerivedColumns>()
+    for (const { application } of rows) {
+        derivedMap.set(application.id, deriveAllColumns(sectionMap.get(application.id) ?? {}))
+    }
+
+    return (
+        <div>
+            <div className="mb-6">
+                <h1 className="text-2xl font-bold">Foster Applications</h1>
+            </div>
+
+            <FostersFilter
+                currentStatus={params.status ?? ""}
+                currentSearch={params.search ?? ""}
+            />
+
+            <Table>
+                <TableHeader>
+                    <TableRow>
+                        <TableHead>Applicant</TableHead>
+                        <TableHead>Submitted</TableHead>
+                        <TableHead>Status</TableHead>
+                        <TableHead>Age</TableHead>
+                        <TableHead>Pets</TableHead>
+                        <TableHead>Kids</TableHead>
+                        <TableHead>Housing</TableHead>
+                        <TableHead>Referral</TableHead>
+                        <TableHead>Also Adopting?</TableHead>
+                    </TableRow>
+                </TableHeader>
+                <TableBody>
+                    {rows.map(({ application }) => {
+                        const derived = derivedMap.get(application.id)
+                        const ageDays = computeAgeDays(application.submittedAt)
+                        return (
+                            <TableRow key={application.id}>
+                                <TableCell>
+                                    <Link
+                                        href={`/fosters/${application.id}`}
+                                        className="font-medium hover:underline"
+                                    >
+                                        {application.firstName} {application.lastName}
+                                    </Link>
+                                    <div className="text-muted-foreground text-sm">
+                                        {application.email}
+                                    </div>
+                                </TableCell>
+                                <TableCell>
+                                    {application.submittedAt
+                                        ? new Date(application.submittedAt).toLocaleDateString()
+                                        : "—"}
+                                </TableCell>
+                                <TableCell>
+                                    <StatusBadge status={application.status} />
+                                </TableCell>
+                                <TableCell>
+                                    {ageDays !== null ? (
+                                        `${ageDays}d`
+                                    ) : (
+                                        <span className="text-muted-foreground">—</span>
+                                    )}
+                                </TableCell>
+                                <TableCell>{derived?.pets ?? "—"}</TableCell>
+                                <TableCell>{derived?.kids ?? "—"}</TableCell>
+                                <TableCell>{derived?.housing ?? "—"}</TableCell>
+                                <TableCell>{derived?.referral ?? "—"}</TableCell>
+                                <TableCell>{derived?.alsoAdopting ?? "—"}</TableCell>
+                            </TableRow>
+                        )
+                    })}
+                    {rows.length === 0 && (
+                        <TableRow>
+                            <TableCell
+                                colSpan={9}
+                                className="text-muted-foreground py-8 text-center"
+                            >
+                                No foster applications found.
+                            </TableCell>
+                        </TableRow>
+                    )}
+                </TableBody>
+            </Table>
+        </div>
+    )
+}

--- a/apps/admin/app/_components/app-sidebar.tsx
+++ b/apps/admin/app/_components/app-sidebar.tsx
@@ -105,6 +105,7 @@ const SECTION_ACCESS: Record<string, RoleName[]> = {
         "Treasurer",
         "Board Member",
     ],
+    fosters: ["Super Admin", "Foster Coordinator", "President", "Vice President"],
 }
 
 function canAccess(roles: RoleName[], section?: string): boolean {
@@ -123,6 +124,7 @@ const adminEntries: NavEntry[] = [
 
 const operationsEntries: NavEntry[] = [
     { title: "Applications", href: "/applications", icon: ClipboardList, section: "applications" },
+    { title: "Fosters", href: "/fosters", icon: Heart, section: "fosters" },
 ]
 
 const navEntries: NavEntry[] = [


### PR DESCRIPTION
Third of 5 PRs. Closes #10.

## Summary

- `/admin/fosters` list page with status filter, name/email search, 9 derived columns (Applicant, Submitted, Status, Age, Pets, Kids, Housing, Referral, Also Adopting?).
- Drafts excluded by default; toggle via filter.
- Sidebar "Fosters" entry under Operations group, gated to Foster Coordinator, President, VP, Super Admin.
- Foster-scoped status badge (no \`adopted\` state).
- Parallel \`derive-columns.ts\` reading foster section shapes (not shared with adoption per design Q12).

## Out of scope
- Detail page at \`/admin/fosters/[id]\` → PR 4 (#11)
- Polish / UX fine-tuning → PR 5 (#12)

## Test plan
- [x] \`pnpm typecheck\` / \`pnpm lint\` / \`pnpm test\` green
- [ ] Manual: sign in as Foster Coordinator — Fosters nav entry visible, page loads
- [ ] Manual: sign in as Adoption Rep — Fosters nav entry hidden, direct \`/fosters\` access redirects
- [ ] Manual: submit a foster application via \`/foster/apply\` — appears in list with derived columns populated

🤖 Generated with [Claude Code](https://claude.com/claude-code)