### PR TITLE
feat(admin): foster application detail at /admin/fosters/[id] (PR 4/5)

### DIFF
--- a/apps/admin/app/(admin)/fosters/[id]/_actions/detail-actions.ts
+++ b/apps/admin/app/(admin)/fosters/[id]/_actions/detail-actions.ts
@@ -1,0 +1,88 @@
+"use server"
+
+import {
+    updateFosterApplicationStatus,
+    upsertFosterMilestone,
+    deleteFosterMilestone,
+    addFosterComment,
+} from "@repo/database"
+import type {
+    FosterApplicationStatus,
+    FosterMilestone,
+    FosterSectionCategory,
+} from "@repo/database"
+import { revalidatePath } from "next/cache"
+import { requireSectionAccess } from "@/app/_lib/require-section-access"
+
+type ActionResult = { success: true } | { errors: string[] }
+
+export async function changeStatusAction(
+    fosterApplicationId: number,
+    status: FosterApplicationStatus,
+): Promise<ActionResult> {
+    const { session } = await requireSectionAccess("fosters")
+    try {
+        await updateFosterApplicationStatus(fosterApplicationId, status, session.user.id)
+        revalidatePath(`/fosters/${fosterApplicationId}`)
+        return { success: true }
+    } catch {
+        return { errors: ["Failed to update status"] }
+    }
+}
+
+export async function setMilestoneAction(
+    fosterApplicationId: number,
+    milestone: FosterMilestone,
+    completedAt: string,
+): Promise<ActionResult> {
+    const { session } = await requireSectionAccess("fosters")
+    try {
+        await upsertFosterMilestone({
+            fosterApplicationId,
+            milestone,
+            completedAt: new Date(completedAt),
+            userId: session.user.id,
+        })
+        revalidatePath(`/fosters/${fosterApplicationId}`)
+        return { success: true }
+    } catch {
+        return { errors: ["Failed to set milestone"] }
+    }
+}
+
+export async function clearMilestoneAction(
+    fosterApplicationId: number,
+    milestone: FosterMilestone,
+): Promise<ActionResult> {
+    await requireSectionAccess("fosters")
+    try {
+        await deleteFosterMilestone(fosterApplicationId, milestone)
+        revalidatePath(`/fosters/${fosterApplicationId}`)
+        return { success: true }
+    } catch {
+        return { errors: ["Failed to clear milestone"] }
+    }
+}
+
+export async function addCommentAction(
+    fosterApplicationId: number,
+    body: string,
+    sectionCategory?: FosterSectionCategory,
+): Promise<ActionResult> {
+    const { session } = await requireSectionAccess("fosters")
+    if (!body.trim()) {
+        return { errors: ["Comment body is required"] }
+    }
+    try {
+        await addFosterComment({
+            fosterApplicationId,
+            userId: session.user.id,
+            body: body.trim(),
+            sectionCategory,
+        })
+        revalidatePath(`/fosters/${fosterApplicationId}`)
+        return { success: true }
+    } catch {
+        return { errors: ["Failed to add comment"] }
+    }
+}

--- a/apps/admin/app/(admin)/fosters/[id]/_components/application-detail.tsx
+++ b/apps/admin/app/(admin)/fosters/[id]/_components/application-detail.tsx
@@ -1,0 +1,108 @@
+"use client"
+
+import { useState } from "react"
+import { useRouter, useSearchParams } from "next/navigation"
+import { Tabs, TabsList, TabsTrigger, TabsContent } from "@repo/ui/components/tabs"
+import { FOSTER_SECTION_CONFIGS } from "@repo/types"
+import type { FosterApplicationComment } from "@repo/types"
+import type { FosterApplicationStatus, FosterMilestone, FosterSectionKey } from "@repo/database"
+import { EnrichmentPanel } from "./enrichment-panel"
+import { SectionTab } from "./section-tab"
+import { DiscussionTab } from "./discussion-tab"
+import { CommentsSheet } from "./comments-sheet"
+
+interface MilestoneData {
+    milestone: {
+        milestone: FosterMilestone
+        completedAt: Date
+    }
+    userName: string
+}
+
+interface FosterApplicationDetailProps {
+    fosterApplicationId: number
+    status: FosterApplicationStatus
+    sections: Partial<Record<FosterSectionKey, Record<string, unknown>>>
+    milestones: MilestoneData[]
+    comments: FosterApplicationComment[]
+}
+
+const TAB_LABELS: Record<string, string> = {
+    applicant_info: "Applicant",
+    household: "Household",
+    pre_foster: "Pre-Foster",
+    home: "Home",
+    current_pets: "Pets",
+    foster_preferences: "Foster",
+    vet_reference: "Vet",
+    personal_references: "References",
+    foster_agreements: "Agreements",
+    final_questions: "Final",
+}
+
+export function FosterApplicationDetail({
+    fosterApplicationId,
+    status,
+    sections,
+    milestones,
+    comments,
+}: FosterApplicationDetailProps) {
+    const router = useRouter()
+    const searchParams = useSearchParams()
+    const initialTab = searchParams.get("tab") ?? "applicant_info"
+    const [activeTab, setActiveTab] = useState(initialTab)
+
+    function handleTabChange(value: string) {
+        setActiveTab(value)
+        const params = new URLSearchParams(searchParams.toString())
+        params.set("tab", value)
+        router.replace(`?${params.toString()}`, { scroll: false })
+    }
+
+    return (
+        <div className="space-y-6">
+            <CommentsSheet
+                fosterApplicationId={fosterApplicationId}
+                comments={comments}
+                activeTab={activeTab}
+            />
+            <EnrichmentPanel
+                fosterApplicationId={fosterApplicationId}
+                status={status}
+                milestones={milestones}
+            />
+
+            <Tabs defaultValue={initialTab} onValueChange={handleTabChange}>
+                <TabsList className="flex-wrap">
+                    {FOSTER_SECTION_CONFIGS.map((section) => (
+                        <TabsTrigger key={section.key} value={section.key}>
+                            {TAB_LABELS[section.key] ?? section.title}
+                        </TabsTrigger>
+                    ))}
+                    <TabsTrigger value="discussion">Discussion</TabsTrigger>
+                </TabsList>
+
+                {FOSTER_SECTION_CONFIGS.map((section) => (
+                    <TabsContent
+                        key={section.key}
+                        value={section.key}
+                        forceMount
+                        className="data-[state=inactive]:hidden"
+                    >
+                        <SectionTab
+                            fosterApplicationId={fosterApplicationId}
+                            sectionKey={section.key}
+                            sectionData={sections[section.key] ?? {}}
+                            allSectionsData={sections}
+                            comments={comments}
+                        />
+                    </TabsContent>
+                ))}
+
+                <TabsContent value="discussion" forceMount className="data-[state=inactive]:hidden">
+                    <DiscussionTab fosterApplicationId={fosterApplicationId} comments={comments} />
+                </TabsContent>
+            </Tabs>
+        </div>
+    )
+}

--- a/apps/admin/app/(admin)/fosters/[id]/_components/comment-form.tsx
+++ b/apps/admin/app/(admin)/fosters/[id]/_components/comment-form.tsx
@@ -1,0 +1,82 @@
+"use client"
+
+import { useState, useTransition } from "react"
+import { toast } from "sonner"
+import { Button } from "@repo/ui/components/button"
+import { Textarea } from "@repo/ui/components/textarea"
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from "@repo/ui/components/select"
+import { FOSTER_SECTION_CONFIG_MAP } from "@repo/types"
+import type { FosterSectionCategory, FosterSectionKey } from "@repo/database"
+import { FOSTER_SECTION_CATEGORIES } from "@repo/database"
+import { addCommentAction } from "../_actions/detail-actions"
+
+interface CommentFormProps {
+    fosterApplicationId: number
+    sectionCategory?: FosterSectionCategory
+    showCategorySelect?: boolean
+}
+
+export function CommentForm({
+    fosterApplicationId,
+    sectionCategory,
+    showCategorySelect,
+}: CommentFormProps) {
+    const [body, setBody] = useState("")
+    const [category, setCategory] = useState<FosterSectionCategory>(sectionCategory ?? "general")
+    const [isPending, startTransition] = useTransition()
+
+    function handleSubmit() {
+        if (!body.trim()) return
+        startTransition(async () => {
+            const effectiveCategory = showCategorySelect ? category : sectionCategory
+            const result = await addCommentAction(fosterApplicationId, body, effectiveCategory)
+            if ("errors" in result) {
+                toast.error(result.errors[0])
+            } else {
+                setBody("")
+            }
+        })
+    }
+
+    return (
+        <div className="space-y-3">
+            <Textarea
+                placeholder="Add a comment..."
+                value={body}
+                onChange={(e) => setBody(e.target.value)}
+                rows={3}
+            />
+            <div className="flex items-center gap-2">
+                {showCategorySelect && (
+                    <Select
+                        value={category}
+                        onValueChange={(v) => setCategory(v as FosterSectionCategory)}
+                    >
+                        <SelectTrigger className="w-48">
+                            <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                            {FOSTER_SECTION_CATEGORIES.map((cat) => (
+                                <SelectItem key={cat} value={cat}>
+                                    {cat === "general"
+                                        ? "General"
+                                        : (FOSTER_SECTION_CONFIG_MAP[cat as FosterSectionKey]
+                                              ?.title ?? cat)}
+                                </SelectItem>
+                            ))}
+                        </SelectContent>
+                    </Select>
+                )}
+                <Button onClick={handleSubmit} disabled={isPending || !body.trim()} size="sm">
+                    {isPending ? "Posting..." : "Post Comment"}
+                </Button>
+            </div>
+        </div>
+    )
+}

--- a/apps/admin/app/(admin)/fosters/[id]/_components/comment-thread.tsx
+++ b/apps/admin/app/(admin)/fosters/[id]/_components/comment-thread.tsx
@@ -1,0 +1,47 @@
+"use client"
+
+import { formatDistanceToNow } from "date-fns"
+import { Badge } from "@repo/ui/components/badge"
+import { FOSTER_SECTION_CONFIG_MAP } from "@repo/types"
+import type { FosterApplicationComment } from "@repo/types"
+import type { FosterSectionKey } from "@repo/database"
+
+interface CommentThreadProps {
+    comments: FosterApplicationComment[]
+    showCategory?: boolean
+}
+
+export function CommentThread({ comments, showCategory }: CommentThreadProps) {
+    if (comments.length === 0) {
+        return <p className="text-muted-foreground text-sm">No comments yet.</p>
+    }
+
+    return (
+        <div className="space-y-4">
+            {comments.map((comment) => (
+                <div key={comment.id} className="space-y-1">
+                    <div className="flex items-center gap-2 text-sm">
+                        <span className="font-medium">{comment.userName}</span>
+                        <span className="text-muted-foreground">
+                            {formatDistanceToNow(new Date(comment.createdAt), { addSuffix: true })}
+                        </span>
+                        {showCategory && comment.sectionCategory && (
+                            <Badge variant="outline" className="text-xs">
+                                {comment.sectionCategory === "general"
+                                    ? "General"
+                                    : (FOSTER_SECTION_CONFIG_MAP[
+                                          comment.sectionCategory as FosterSectionKey
+                                      ]?.title ?? comment.sectionCategory)}
+                            </Badge>
+                        )}
+                    </div>
+                    <p
+                        className={`text-sm ${comment.isSystemEvent ? "text-muted-foreground italic" : ""}`}
+                    >
+                        {comment.body}
+                    </p>
+                </div>
+            ))}
+        </div>
+    )
+}

--- a/apps/admin/app/(admin)/fosters/[id]/_components/comments-sheet.tsx
+++ b/apps/admin/app/(admin)/fosters/[id]/_components/comments-sheet.tsx
@@ -1,0 +1,56 @@
+"use client"
+
+import { useState } from "react"
+import { MessageSquare } from "lucide-react"
+import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@repo/ui/components/sheet"
+import type { FosterApplicationComment } from "@repo/types"
+import type { FosterSectionCategory } from "@repo/database"
+import { CommentThread } from "./comment-thread"
+import { CommentForm } from "./comment-form"
+
+interface CommentsSheetProps {
+    fosterApplicationId: number
+    comments: FosterApplicationComment[]
+    activeTab: string
+}
+
+export function CommentsSheet({ fosterApplicationId, comments, activeTab }: CommentsSheetProps) {
+    const [open, setOpen] = useState(false)
+    const isDiscussion = activeTab === "discussion"
+    const filteredComments = isDiscussion
+        ? comments
+        : comments.filter((c) => c.sectionCategory === activeTab)
+
+    return (
+        <>
+            <button
+                onClick={() => setOpen(true)}
+                className="bg-background hover:bg-accent fixed top-1/2 right-0 z-40 flex -translate-y-1/2 items-center gap-1.5 rounded-l-md border border-r-0 px-2 py-3 shadow-md transition-colors"
+                style={{ writingMode: "vertical-rl" }}
+            >
+                <MessageSquare className="size-4 rotate-90" />
+                <span className="text-sm font-medium">Comments</span>
+            </button>
+
+            <Sheet open={open} onOpenChange={setOpen}>
+                <SheetContent className="flex w-1/3 min-w-80 flex-col sm:max-w-none">
+                    <SheetHeader>
+                        <SheetTitle>Comments</SheetTitle>
+                    </SheetHeader>
+                    <div className="flex-1 overflow-y-auto px-4">
+                        <CommentThread comments={filteredComments} showCategory={isDiscussion} />
+                    </div>
+                    <div className="border-t p-4">
+                        <CommentForm
+                            fosterApplicationId={fosterApplicationId}
+                            sectionCategory={
+                                isDiscussion ? undefined : (activeTab as FosterSectionCategory)
+                            }
+                            showCategorySelect={isDiscussion}
+                        />
+                    </div>
+                </SheetContent>
+            </Sheet>
+        </>
+    )
+}

--- a/apps/admin/app/(admin)/fosters/[id]/_components/discussion-tab.tsx
+++ b/apps/admin/app/(admin)/fosters/[id]/_components/discussion-tab.tsx
@@ -1,0 +1,20 @@
+"use client"
+
+import type { FosterApplicationComment } from "@repo/types"
+import { CommentThread } from "./comment-thread"
+import { CommentForm } from "./comment-form"
+
+interface DiscussionTabProps {
+    fosterApplicationId: number
+    comments: FosterApplicationComment[]
+}
+
+export function DiscussionTab({ fosterApplicationId, comments }: DiscussionTabProps) {
+    return (
+        <div className="space-y-6 pt-4">
+            <h3 className="text-lg font-semibold">Discussion</h3>
+            <CommentThread comments={comments} showCategory />
+            <CommentForm fosterApplicationId={fosterApplicationId} showCategorySelect />
+        </div>
+    )
+}

--- a/apps/admin/app/(admin)/fosters/[id]/_components/enrichment-panel.tsx
+++ b/apps/admin/app/(admin)/fosters/[id]/_components/enrichment-panel.tsx
@@ -1,0 +1,136 @@
+"use client"
+
+import { useTransition } from "react"
+import { toast } from "sonner"
+import { format } from "date-fns"
+import { CalendarIcon, XIcon } from "lucide-react"
+import { Button } from "@repo/ui/components/button"
+import { Label } from "@repo/ui/components/label"
+import { Popover, PopoverContent, PopoverTrigger } from "@repo/ui/components/popover"
+import { Calendar } from "@repo/ui/components/calendar"
+import type { FosterApplicationStatus, FosterMilestone } from "@repo/database"
+import { FOSTER_MILESTONES } from "@repo/database"
+import { StatusControls } from "./status-controls"
+import { setMilestoneAction, clearMilestoneAction } from "../_actions/detail-actions"
+
+interface MilestoneData {
+    milestone: {
+        milestone: FosterMilestone
+        completedAt: Date
+    }
+    userName: string
+}
+
+interface EnrichmentPanelProps {
+    fosterApplicationId: number
+    status: FosterApplicationStatus
+    milestones: MilestoneData[]
+}
+
+const MILESTONE_LABELS: Record<FosterMilestone, string> = {
+    screened: "Screened",
+    interviewed: "Interviewed",
+    reference_check: "References",
+    home_visit: "Home Visit",
+    approved: "Approved",
+}
+
+export function EnrichmentPanel({ fosterApplicationId, status, milestones }: EnrichmentPanelProps) {
+    const milestoneMap = new Map(milestones.map((m) => [m.milestone.milestone, m.milestone]))
+
+    return (
+        <div className="space-y-6 rounded-lg border p-4">
+            <div className="space-y-1.5">
+                <Label>Status</Label>
+                <StatusControls fosterApplicationId={fosterApplicationId} currentStatus={status} />
+            </div>
+
+            <div>
+                <Label className="mb-2 block">Activity Dates</Label>
+                <div className="grid grid-cols-2 gap-3 md:grid-cols-3 lg:grid-cols-5">
+                    {FOSTER_MILESTONES.map((milestone) => (
+                        <MilestoneDatePicker
+                            key={milestone}
+                            fosterApplicationId={fosterApplicationId}
+                            milestone={milestone}
+                            label={MILESTONE_LABELS[milestone]}
+                            currentDate={milestoneMap.get(milestone)?.completedAt ?? null}
+                        />
+                    ))}
+                </div>
+            </div>
+        </div>
+    )
+}
+
+function MilestoneDatePicker({
+    fosterApplicationId,
+    milestone,
+    label,
+    currentDate,
+}: {
+    fosterApplicationId: number
+    milestone: FosterMilestone
+    label: string
+    currentDate: Date | null
+}) {
+    const [isPending, startTransition] = useTransition()
+
+    function handleSelect(date: Date | undefined) {
+        if (!date) return
+        startTransition(async () => {
+            const result = await setMilestoneAction(
+                fosterApplicationId,
+                milestone,
+                date.toISOString(),
+            )
+            if ("errors" in result) toast.error(result.errors[0])
+        })
+    }
+
+    function handleClear() {
+        startTransition(async () => {
+            const result = await clearMilestoneAction(fosterApplicationId, milestone)
+            if ("errors" in result) toast.error(result.errors[0])
+        })
+    }
+
+    return (
+        <div className="space-y-1">
+            <span className="text-muted-foreground text-xs">{label}</span>
+            <div className="flex items-center gap-1">
+                <Popover>
+                    <PopoverTrigger asChild>
+                        <Button
+                            variant="outline"
+                            size="sm"
+                            className="w-full justify-start text-left text-xs font-normal"
+                            disabled={isPending}
+                        >
+                            <CalendarIcon className="mr-1 h-3 w-3" />
+                            {currentDate ? format(new Date(currentDate), "MM/dd/yy") : "Set date"}
+                        </Button>
+                    </PopoverTrigger>
+                    <PopoverContent className="w-auto p-0" align="start">
+                        <Calendar
+                            mode="single"
+                            selected={currentDate ? new Date(currentDate) : undefined}
+                            onSelect={handleSelect}
+                        />
+                    </PopoverContent>
+                </Popover>
+                {currentDate && (
+                    <Button
+                        variant="ghost"
+                        size="icon"
+                        className="h-7 w-7 shrink-0"
+                        onClick={handleClear}
+                        disabled={isPending}
+                    >
+                        <XIcon className="h-3 w-3" />
+                    </Button>
+                )}
+            </div>
+        </div>
+    )
+}

--- a/apps/admin/app/(admin)/fosters/[id]/_components/section-tab.tsx
+++ b/apps/admin/app/(admin)/fosters/[id]/_components/section-tab.tsx
@@ -1,0 +1,58 @@
+"use client"
+
+import { ApplicationSectionDisplay } from "@repo/ui/components/application-section-display"
+import { Separator } from "@repo/ui/components/separator"
+import { FOSTER_CONDITIONAL_RULES, FOSTER_SECTION_CONFIG_MAP } from "@repo/types"
+import type { FosterApplicationComment } from "@repo/types"
+import type { FosterSectionKey } from "@repo/database"
+import { CommentThread } from "./comment-thread"
+import { CommentForm } from "./comment-form"
+
+interface SectionTabProps {
+    fosterApplicationId: number
+    sectionKey: FosterSectionKey
+    sectionData: Record<string, unknown>
+    allSectionsData: Partial<Record<FosterSectionKey, Record<string, unknown>>>
+    comments: FosterApplicationComment[]
+}
+
+export function SectionTab({
+    fosterApplicationId,
+    sectionKey,
+    sectionData,
+    allSectionsData,
+    comments,
+}: SectionTabProps) {
+    const sectionConfig = FOSTER_SECTION_CONFIG_MAP[sectionKey]
+    const sectionComments = comments.filter((c) => c.sectionCategory === sectionKey)
+
+    return (
+        <div className="space-y-6 pt-4">
+            <div>
+                <h3 className="text-lg font-semibold">{sectionConfig.title}</h3>
+                {sectionConfig.description && (
+                    <p className="text-muted-foreground text-sm">{sectionConfig.description}</p>
+                )}
+            </div>
+
+            <ApplicationSectionDisplay
+                sectionConfig={sectionConfig}
+                data={sectionData}
+                allSectionsData={allSectionsData}
+                conditionalRules={FOSTER_CONDITIONAL_RULES}
+                configMap={FOSTER_SECTION_CONFIG_MAP}
+            />
+
+            <Separator />
+
+            <div className="space-y-4">
+                <h4 className="text-sm font-medium">Comments</h4>
+                <CommentThread comments={sectionComments} />
+                <CommentForm
+                    fosterApplicationId={fosterApplicationId}
+                    sectionCategory={sectionKey}
+                />
+            </div>
+        </div>
+    )
+}

--- a/apps/admin/app/(admin)/fosters/[id]/_components/status-controls.tsx
+++ b/apps/admin/app/(admin)/fosters/[id]/_components/status-controls.tsx
@@ -1,0 +1,95 @@
+"use client"
+
+import { useState, useTransition } from "react"
+import { toast } from "sonner"
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from "@repo/ui/components/select"
+import {
+    AlertDialog,
+    AlertDialogAction,
+    AlertDialogCancel,
+    AlertDialogContent,
+    AlertDialogDescription,
+    AlertDialogFooter,
+    AlertDialogHeader,
+    AlertDialogTitle,
+} from "@repo/ui/components/alert-dialog"
+import { StatusBadge } from "../../_components/status-badge"
+import type { FosterApplicationStatus } from "@repo/database"
+import { FOSTER_APPLICATION_STATUSES } from "@repo/database"
+import { changeStatusAction } from "../_actions/detail-actions"
+
+const STATUS_LABELS: Record<FosterApplicationStatus, string> = {
+    draft: "Draft",
+    submitted: "Submitted",
+    in_review: "In Review",
+    approved: "Approved",
+    denied: "Denied",
+    on_hold: "On Hold",
+}
+
+interface StatusControlsProps {
+    fosterApplicationId: number
+    currentStatus: FosterApplicationStatus
+}
+
+export function StatusControls({ fosterApplicationId, currentStatus }: StatusControlsProps) {
+    const [pendingStatus, setPendingStatus] = useState<FosterApplicationStatus | null>(null)
+    const [isPending, startTransition] = useTransition()
+
+    function handleConfirm() {
+        if (!pendingStatus) return
+        startTransition(async () => {
+            const result = await changeStatusAction(fosterApplicationId, pendingStatus)
+            if ("errors" in result) {
+                toast.error(result.errors[0])
+            }
+            setPendingStatus(null)
+        })
+    }
+
+    return (
+        <div className="flex items-center gap-3">
+            <StatusBadge status={currentStatus} />
+            <Select
+                value={currentStatus}
+                onValueChange={(v) => setPendingStatus(v as FosterApplicationStatus)}
+            >
+                <SelectTrigger className="w-36">
+                    <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                    {FOSTER_APPLICATION_STATUSES.map((status) => (
+                        <SelectItem key={status} value={status}>
+                            {STATUS_LABELS[status]}
+                        </SelectItem>
+                    ))}
+                </SelectContent>
+            </Select>
+
+            <AlertDialog open={!!pendingStatus} onOpenChange={() => setPendingStatus(null)}>
+                <AlertDialogContent>
+                    <AlertDialogHeader>
+                        <AlertDialogTitle>Change Status</AlertDialogTitle>
+                        <AlertDialogDescription>
+                            Change status from <strong>{STATUS_LABELS[currentStatus]}</strong> to{" "}
+                            <strong>{pendingStatus ? STATUS_LABELS[pendingStatus] : ""}</strong>?
+                            This will be recorded in the application timeline.
+                        </AlertDialogDescription>
+                    </AlertDialogHeader>
+                    <AlertDialogFooter>
+                        <AlertDialogCancel>Cancel</AlertDialogCancel>
+                        <AlertDialogAction onClick={handleConfirm} disabled={isPending}>
+                            {isPending ? "Changing..." : "Confirm"}
+                        </AlertDialogAction>
+                    </AlertDialogFooter>
+                </AlertDialogContent>
+            </AlertDialog>
+        </div>
+    )
+}

--- a/apps/admin/app/(admin)/fosters/[id]/page.tsx
+++ b/apps/admin/app/(admin)/fosters/[id]/page.tsx
@@ -1,0 +1,75 @@
+import {
+    getFosterApplication,
+    getLatestFosterSections,
+    getFosterMilestones,
+    getFosterComments,
+} from "@repo/database"
+import type { FosterSectionKey } from "@repo/database"
+import type { FosterApplicationComment } from "@repo/types"
+import { requireSectionAccess } from "@/app/_lib/require-section-access"
+import { notFound } from "next/navigation"
+import Link from "next/link"
+import { Suspense } from "react"
+import { Button } from "@repo/ui/components/button"
+import { ArrowLeft } from "lucide-react"
+import { FosterApplicationDetail } from "./_components/application-detail"
+
+interface PageProps {
+    params: Promise<{ id: string }>
+}
+
+export default async function FosterApplicationDetailPage({ params }: PageProps) {
+    await requireSectionAccess("fosters")
+    const { id } = await params
+    const numericId = Number(id)
+
+    const [application, sectionsRows, milestones, commentRows] = await Promise.all([
+        getFosterApplication(numericId),
+        getLatestFosterSections(numericId),
+        getFosterMilestones(numericId),
+        getFosterComments(numericId),
+    ])
+
+    if (!application) notFound()
+
+    const sections: Partial<Record<FosterSectionKey, Record<string, unknown>>> = {}
+    for (const row of sectionsRows) {
+        sections[row.section.sectionKey] = row.section.data as Record<string, unknown>
+    }
+
+    const comments: FosterApplicationComment[] = commentRows.map((row) => ({
+        id: row.comment.id,
+        fosterApplicationId: row.comment.fosterApplicationId,
+        userId: row.comment.userId,
+        userName: row.userName,
+        sectionCategory: row.comment.sectionCategory,
+        body: row.comment.body,
+        isSystemEvent: row.comment.isSystemEvent,
+        createdAt: row.comment.createdAt,
+    }))
+
+    return (
+        <div>
+            <div className="mb-6 flex items-center gap-4">
+                <Button variant="ghost" size="sm" asChild>
+                    <Link href="/fosters">
+                        <ArrowLeft className="mr-1 h-4 w-4" />
+                        Back
+                    </Link>
+                </Button>
+                <h1 className="text-2xl font-bold">
+                    {application.firstName} {application.lastName}
+                </h1>
+            </div>
+            <Suspense>
+                <FosterApplicationDetail
+                    fosterApplicationId={application.id}
+                    status={application.status}
+                    sections={sections}
+                    milestones={milestones}
+                    comments={comments}
+                />
+            </Suspense>
+        </div>
+    )
+}


### PR DESCRIPTION
Fourth of 5 PRs. Closes #11.

## Summary

- Detail page at \`/admin/fosters/[id]\` with tabs over the 10 foster sections plus a Discussion tab.
- Per-section comment thread scoped to that tab's category; Discussion tab shows all with category badges.
- Slide-out CommentsSheet (writing-mode:vertical-rl trigger, matches adoption).
- Enrichment panel: status dropdown + 5 foster milestone date pickers (Screened / Interviewed / References / Home Visit / Approved). **No hound selector, no rep assignment.**
- Status controls use foster-only statuses (no \`adopted\`).
- Server actions gated on \`requireSectionAccess(\"fosters\")\`.

## Out of scope
- Polish: FieldRenderer consolidation, submission-notification wiring, derived-column tuning → PR 5 (#12).

## Test plan
- [x] \`pnpm typecheck\` / \`pnpm lint\` / \`pnpm test\` green
- [ ] Manual: open a submitted foster application — all 10 section tabs render, conditional fields hide/show correctly
- [ ] Manual: status change, milestone set/clear persist; section-scoped and general comments both work
- [ ] Manual: sign in as Adoption Rep — direct \`/fosters/:id\` access redirects
- [ ] Manual: Foster Coordinator sees full detail with no hound/rep controls

🤖 Generated with [Claude Code](https://claude.com/claude-code)