### PR TITLE
fix(web): link /volunteer Apply to Foster CTA to /foster/apply

### DIFF
--- a/apps/web/app/volunteer/page.tsx
+++ b/apps/web/app/volunteer/page.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link"
 import {
     getVolunteerRoles,
     getPageHeader,
@@ -64,12 +65,12 @@ export default async function VolunteerPage() {
                                         />
                                     )}
                                     <div className="mt-8">
-                                        <a
-                                            href="mailto:fostering@gpa-mn.org"
+                                        <Link
+                                            href="/foster/apply"
                                             className="bg-primary hover:bg-primary/90 inline-flex items-center gap-2 rounded-full px-8 py-3.5 font-semibold text-white shadow-[0_4px_16px_rgba(156,47,48,0.25)] transition-colors"
                                         >
                                             Apply to Foster
-                                        </a>
+                                        </Link>
                                     </div>
                                 </div>
                             </div>


### PR DESCRIPTION
## Summary

- Replaces the \`mailto:fostering@gpa-mn.org\` link on \`/volunteer\` with a Next.js \`Link\` to \`/foster/apply\`.
- The mailto was retained while the wizard was being rolled out across PRs #13–#17. Now that \`/foster/apply\` is live on main, the CTA should drive applicants into the hosted form.

## Test plan
- [ ] Manual: click "Apply to Foster" on \`/volunteer\` → lands on \`/foster/apply\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)